### PR TITLE
fixed play again button

### DIFF
--- a/Project Folder/game.php
+++ b/Project Folder/game.php
@@ -759,10 +759,6 @@
                     else{
                         wrongTotal++;
 
-                        if(wrongTotal >= strikes){
-                            youLose();
-                        }
-
                         return false;
                     }
                 }
@@ -946,6 +942,10 @@
                 removeMatheroid(0);
             }
             else{
+                if(wrongTotal >= strikes){
+                    youLose();
+                }
+
                 laserReflects = true;
 
                 damageSounds[damageSoundIdx].play();
@@ -957,7 +957,9 @@
                 }
             }
 
-            updateTop();
+            if(playing){
+                updateTop();
+            }
 
             document.getElementById("userAnswer").value = "";
         }


### PR DESCRIPTION
updateTop was being called a second time if you lost by striking out, so it was clearing the play again button.

Now updateTop() is only called at the end of shoot() if the game is being played.